### PR TITLE
Use unauthenticated base image as reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# FROM registry.redhat.io/fuse7/fuse-java-openshift
-FROM quay.io/makentenza/fuse-java-openshift
+FROM registry.access.redhat.com/fuse7/fuse-java-openshift
 
 USER root
 


### PR DESCRIPTION
Move to official container image using unauthenticated reference